### PR TITLE
Fixed issue: device rotation put always the header view on top of the web view

### DIFF
--- a/HeaderWebView/EmailView.m
+++ b/HeaderWebView/EmailView.m
@@ -42,9 +42,9 @@
 }
 
 #pragma mark -
-#pragma mark - NSKeyObserving
+#pragma mark - Interface layout
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+- (void)updateLayout
 {
     // Update the frame of the header view so that it scrolls with the webview content
     CGRect newFrame = self.headerView.frame;
@@ -68,6 +68,14 @@
     
     // Call the delegate for the full screen
     [self.fullScreenDelegate emailView:self showFullScreen:fullScreen];
+}
+
+#pragma mark -
+#pragma mark - NSKeyObserving
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    [self updateLayout];
 }
 
 #pragma mark -
@@ -142,6 +150,8 @@
         newFrame.origin.y = CGRectGetHeight(self.headerView.frame);
         [subview setFrame:newFrame];
     }
+    
+    [self updateLayout];
 }
 
 #pragma mark -

--- a/HeaderWebView/Info.plist
+++ b/HeaderWebView/Info.plist
@@ -45,5 +45,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
The device rotation forces a main view layout, causing the header to be located at the top of the view (y=0). I modified the method layoutSubviews of EmailView class to force an update of y coordinate on every layout call to keep the previous location in the scrollview.
Moreover, I added the NSAppTransportSecurity flag to make the demo working with iOS 9+.
